### PR TITLE
chore(wiremock-micronaut): Bumped-up dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In your `pom.xml`, simply add the `wiremock-micronaut` dependency:
 <dependency>
     <groupId>io.github.nahuel92</groupId>
     <artifactId>wiremock-micronaut</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -28,7 +28,6 @@ Use `@EnableWireMock` with `@ConfigureWireMock` with tests annotated that use `M
 like `@MicronautTest`:
 
 ```java
-
 @MicronautTest
 @EnableWireMock(
         @ConfigureWireMock(

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -4,12 +4,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>wiremock-example</artifactId>
-    <version>1.3.0</version>
+    <version>1.5.0</version>
 
     <parent>
         <groupId>io.github.nahuel92</groupId>
         <artifactId>wiremock-micronaut-parent</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
     </parent>
 
     <name>WireMock Micronaut Example</name>
@@ -18,8 +18,8 @@
 
     <properties>
         <jdk.version>21</jdk.version>
-        <micronaut.core.version>4.5.1</micronaut.core.version>
-        <wiremock.micronaut.version>1.4.0</wiremock.micronaut.version>
+        <micronaut.core.version>4.5.3</micronaut.core.version>
+        <wiremock.micronaut.version>1.5.0</wiremock.micronaut.version>
     </properties>
 
     <dependencies>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-inject</artifactId>
-            <version>4.5.1</version>
+            <version>${micronaut.core.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -121,7 +121,7 @@
             <plugin>
                 <groupId>io.github.ascopes</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>2.1.4</version>
+                <version>2.2.0</version>
                 <configuration>
                     <protocVersion>3.25.3</protocVersion>
                     <sourceDirectories>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.nahuel92</groupId>
     <artifactId>wiremock-micronaut-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <packaging>pom</packaging>
 
     <properties>
         <java.version>21</java.version>
-        <micronaut.version>4.4.3</micronaut.version>
-        <wiremock.version>3.6.0</wiremock.version>
+        <micronaut.version>4.5.0</micronaut.version>
+        <wiremock.version>3.7.0</wiremock.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/wiremock-micronaut/pom.xml
+++ b/wiremock-micronaut/pom.xml
@@ -3,12 +3,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>wiremock-micronaut</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
 
     <parent>
         <groupId>io.github.nahuel92</groupId>
         <artifactId>wiremock-micronaut-parent</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
 
     <properties>
         <jdk.version>21</jdk.version>
-        <micronaut.core.version>4.4.3</micronaut.core.version>
+        <micronaut.core.version>4.5.3</micronaut.core.version>
     </properties>
 
     <dependencies>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-inject</artifactId>
-            <version>4.5.1</version>
+            <version>${micronaut.core.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-runtime</artifactId>
-            <version>4.4.10</version>
+            <version>${micronaut.core.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
* Micronaut -> 4.5.3
* Protobuf-maven-plugin -> 2.2.0
* Wiremock -> 3.7.0