### PR TITLE
Update to Jetty12 versions of WireMock and WireMock gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In your `pom.xml`, simply add the `wiremock-micronaut` dependency:
 <dependency>
   <groupId>io.github.nahuel92</groupId>
   <artifactId>wiremock-micronaut</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -301,7 +301,7 @@ In the following example, WireMock is instructed to:
                 name = GreeterGrpc.SERVICE_NAME,
                 portProperty = "my.port",
                 properties = "my.server",
-                extensionFactories = GrpcExtensionFactory.class,
+                extensionFactories = Jetty12GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock"
         )
 })
@@ -336,14 +336,14 @@ It also supports multiple gRPC and HTTP stubs at the same time, although you may
                 name = GreeterGrpc.SERVICE_NAME,
                 portProperty = "my.port",
                 properties = "my.server",
-                extensionFactories = GrpcExtensionFactory.class,
+                extensionFactories = Jetty12GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock"
         ),
         @ConfigureWireMock(
                 name = Greeter2Grpc.SERVICE_NAME,
                 portProperty = "my.port2",
                 properties = "my.server2",
-                extensionFactories = GrpcExtensionFactory.class,
+                extensionFactories = Jetty12GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock2"
         ),
         @ConfigureWireMock(name = "user-client", properties = "user-client.url")

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -72,7 +72,8 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock-grpc-extension</artifactId>
+            <artifactId>wiremock-grpc-extension-jetty12</artifactId>
+            <version>0.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/example/src/test/java/app/GrpcAndHttpTest.java
+++ b/example/src/test/java/app/GrpcAndHttpTest.java
@@ -10,7 +10,7 @@ import mypackage.HelloRequest2;
 import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.wiremock.grpc.GrpcExtensionFactory;
+import org.wiremock.grpc.Jetty12GrpcExtensionFactory;
 import org.wiremock.grpc.dsl.WireMockGrpcService;
 
 import static org.wiremock.grpc.dsl.WireMockGrpc.equalToMessage;
@@ -22,14 +22,14 @@ import static org.wiremock.grpc.dsl.WireMockGrpc.method;
                 name = GreeterGrpc.SERVICE_NAME,
                 portProperty = "my.port",
                 properties = "my.server",
-                extensionFactories = GrpcExtensionFactory.class,
+                extensionFactories = Jetty12GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock"
         ),
         @ConfigureWireMock(
                 name = Greeter2Grpc.SERVICE_NAME,
                 portProperty = "my.port2",
                 properties = "my.server2",
-                extensionFactories = GrpcExtensionFactory.class,
+                extensionFactories = Jetty12GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock2"
         ),
         @ConfigureWireMock(name = "user-client", properties = "user-client.url")

--- a/example/src/test/java/app/GrpcTest.java
+++ b/example/src/test/java/app/GrpcTest.java
@@ -10,7 +10,7 @@ import mypackage.HelloRequest2;
 import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.wiremock.grpc.GrpcExtensionFactory;
+import org.wiremock.grpc.Jetty12GrpcExtensionFactory;
 import org.wiremock.grpc.dsl.WireMockGrpcService;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,14 +23,14 @@ import static org.wiremock.grpc.dsl.WireMockGrpc.method;
                 name = GreeterGrpc.SERVICE_NAME,
                 portProperty = "my.port",
                 properties = "my.server",
-                extensionFactories = GrpcExtensionFactory.class,
+                extensionFactories = Jetty12GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock"
         ),
         @ConfigureWireMock(
                 name = Greeter2Grpc.SERVICE_NAME,
                 portProperty = "my.port2",
                 properties = "my.server2",
-                extensionFactories = GrpcExtensionFactory.class,
+                extensionFactories = Jetty12GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock2"
         )
 })

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <guava.version>33.4.8-jre</guava.version>
-        <micronaut-parent.version>4.7.6</micronaut-parent.version>
+        <micronaut-parent.version>4.8.2</micronaut-parent.version>
         <wiremock.version>4.0.0-beta.2</wiremock.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <guava.version>33.4.8-jre</guava.version>
         <micronaut-parent.version>4.7.6</micronaut-parent.version>
-        <wiremock.version>3.13.0</wiremock.version>
+        <wiremock.version>4.0.0-beta.2</wiremock.version>
     </properties>
 
     <name>WireMock Micronaut Parent</name>
@@ -73,7 +73,7 @@
 
             <dependency>
                 <groupId>org.wiremock</groupId>
-                <artifactId>wiremock-grpc-extension</artifactId>
+                <artifactId>wiremock-grpc-extension-jetty12</artifactId>
                 <version>0.10.0</version>
             </dependency>
             <dependency>

--- a/wiremock-micronaut/pom.xml
+++ b/wiremock-micronaut/pom.xml
@@ -51,11 +51,13 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
+            <version>4.0.0-beta.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock-grpc-extension</artifactId>
+            <artifactId>wiremock-grpc-extension-jetty12</artifactId>
+            <version>0.10.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/wiremock-micronaut/src/main/java/io/github/nahuel92/wiremock/micronaut/WireMockMicronautExtension.java
+++ b/wiremock-micronaut/src/main/java/io/github/nahuel92/wiremock/micronaut/WireMockMicronautExtension.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wiremock.grpc.GrpcExtensionFactory;
+import org.wiremock.grpc.Jetty12GrpcExtensionFactory;
 import org.wiremock.grpc.dsl.WireMockGrpcService;
 
 import java.util.HashMap;
@@ -141,7 +141,7 @@ class WireMockMicronautExtension extends MicronautJunit5Extension {
 
     private boolean isGrpcTest(final ConfigureWireMock options) {
         for (final var extensionFactory : options.extensionFactories()) {
-            if (extensionFactory.equals(GrpcExtensionFactory.class)) {
+            if (extensionFactory.equals(Jetty12GrpcExtensionFactory.class)) {
                 return true;
             }
         }


### PR DESCRIPTION
Update to the jetty 12 version of the wiremock gRPC extension and moves to the 4.x beta version of WireMock as this ships with jetty 12 by default.  These versions should now match the version of jetty being used by the latest micronaut version

Fixes #42