### PR TITLE
chore(deps): Update dependencies to allow use with latest Micronaut

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ In the following example, WireMock is instructed to:
                 name = GreeterGrpc.SERVICE_NAME,
                 portProperty = "my.port",
                 properties = "my.server",
-                extensionFactories = Jetty12GrpcExtensionFactory.class,
+                extensionFactories = GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock"
         )
 })
@@ -336,14 +336,14 @@ It also supports multiple gRPC and HTTP stubs at the same time, although you may
                 name = GreeterGrpc.SERVICE_NAME,
                 portProperty = "my.port",
                 properties = "my.server",
-                extensionFactories = Jetty12GrpcExtensionFactory.class,
+                extensionFactories = GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock"
         ),
         @ConfigureWireMock(
                 name = Greeter2Grpc.SERVICE_NAME,
                 portProperty = "my.port2",
                 properties = "my.server2",
-                extensionFactories = Jetty12GrpcExtensionFactory.class,
+                extensionFactories = GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock2"
         ),
         @ConfigureWireMock(name = "user-client", properties = "user-client.url")

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock-grpc-extension-jetty12</artifactId>
+            <artifactId>wiremock-grpc-extension-jetty</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/example/src/test/java/app/GrpcAndHttpTest.java
+++ b/example/src/test/java/app/GrpcAndHttpTest.java
@@ -10,7 +10,7 @@ import mypackage.HelloRequest2;
 import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.wiremock.grpc.Jetty12GrpcExtensionFactory;
+import org.wiremock.grpc.GrpcExtensionFactory;
 import org.wiremock.grpc.dsl.WireMockGrpcService;
 
 import static org.wiremock.grpc.dsl.WireMockGrpc.equalToMessage;
@@ -22,14 +22,14 @@ import static org.wiremock.grpc.dsl.WireMockGrpc.method;
                 name = GreeterGrpc.SERVICE_NAME,
                 portProperty = "my.port",
                 properties = "my.server",
-                extensionFactories = Jetty12GrpcExtensionFactory.class,
+                extensionFactories = GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock"
         ),
         @ConfigureWireMock(
                 name = Greeter2Grpc.SERVICE_NAME,
                 portProperty = "my.port2",
                 properties = "my.server2",
-                extensionFactories = Jetty12GrpcExtensionFactory.class,
+                extensionFactories = GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock2"
         ),
         @ConfigureWireMock(name = "user-client", properties = "user-client.url")

--- a/example/src/test/java/app/GrpcTest.java
+++ b/example/src/test/java/app/GrpcTest.java
@@ -10,7 +10,7 @@ import mypackage.HelloRequest2;
 import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.wiremock.grpc.Jetty12GrpcExtensionFactory;
+import org.wiremock.grpc.GrpcExtensionFactory;
 import org.wiremock.grpc.dsl.WireMockGrpcService;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,14 +23,14 @@ import static org.wiremock.grpc.dsl.WireMockGrpc.method;
                 name = GreeterGrpc.SERVICE_NAME,
                 portProperty = "my.port",
                 properties = "my.server",
-                extensionFactories = Jetty12GrpcExtensionFactory.class,
+                extensionFactories = GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock"
         ),
         @ConfigureWireMock(
                 name = Greeter2Grpc.SERVICE_NAME,
                 portProperty = "my.port2",
                 properties = "my.server2",
-                extensionFactories = Jetty12GrpcExtensionFactory.class,
+                extensionFactories = GrpcExtensionFactory.class,
                 stubLocation = "src/test/resources/wiremock2"
         )
 })

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <guava.version>33.4.8-jre</guava.version>
-        <micronaut-parent.version>4.8.2</micronaut-parent.version>
-        <wiremock.version>4.0.0-beta.2</wiremock.version>
+        <micronaut-parent.version>4.10.7</micronaut-parent.version>
+        <wiremock.version>4.0.0-beta.27</wiremock.version>
     </properties>
 
     <name>WireMock Micronaut Parent</name>
@@ -73,8 +73,8 @@
 
             <dependency>
                 <groupId>org.wiremock</groupId>
-                <artifactId>wiremock-grpc-extension-jetty12</artifactId>
-                <version>0.10.0</version>
+                <artifactId>wiremock-grpc-extension-jetty</artifactId>
+                <version>1.0.0-beta.5</version>
             </dependency>
             <dependency>
                 <groupId>org.wiremock</groupId>
@@ -115,7 +115,7 @@
                 <plugin>
                     <groupId>io.micronaut.maven</groupId>
                     <artifactId>micronaut-maven-plugin</artifactId>
-                    <version>4.8.2</version>
+                    <version>4.10.7</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>io.micronaut.grpc</groupId>
                 <artifactId>micronaut-grpc-client-runtime</artifactId>
-                <version>4.9.0</version>
+                <version>4.12.0</version>
             </dependency>
             <dependency>
                 <groupId>io.micronaut.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <guava.version>33.4.8-jre</guava.version>
+        <guava.version>33.5.0-jre</guava.version>
         <micronaut-parent.version>4.10.7</micronaut-parent.version>
         <wiremock.version>4.0.0-beta.27</wiremock.version>
     </properties>

--- a/wiremock-micronaut/pom.xml
+++ b/wiremock-micronaut/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock-grpc-extension-jetty12</artifactId>
+            <artifactId>wiremock-grpc-extension-jetty</artifactId>
             <scope>compile</scope>
         </dependency>
 

--- a/wiremock-micronaut/src/main/java/io/github/nahuel92/wiremock/micronaut/WireMockMicronautExtension.java
+++ b/wiremock-micronaut/src/main/java/io/github/nahuel92/wiremock/micronaut/WireMockMicronautExtension.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wiremock.grpc.Jetty12GrpcExtensionFactory;
+import org.wiremock.grpc.GrpcExtensionFactory;
 import org.wiremock.grpc.dsl.WireMockGrpcService;
 
 import java.util.HashMap;
@@ -141,7 +141,7 @@ class WireMockMicronautExtension extends MicronautJunit5Extension {
 
     private boolean isGrpcTest(final ConfigureWireMock options) {
         for (final var extensionFactory : options.extensionFactories()) {
-            if (extensionFactory.equals(Jetty12GrpcExtensionFactory.class)) {
+            if (extensionFactory.equals(GrpcExtensionFactory.class)) {
                 return true;
             }
         }


### PR DESCRIPTION
This PR updates a number of dependency versions.  Most notable of these are the WireMock dependencies.  As it stands, the versions used in this extension are blocking me updating to the latest micronaut because micronaut uses the latest version of Jetty in the later releases which conflicted with the versions used in WireMock.   This PR resolves this by updating to the latest beta versions of both WireMock and the WireMock grpc extension.

Versions updated in this PR:
* WireMock `4.0.0-beta.2` -> `4.0.0-beta.27`
* WireMock gRPC Extension `0.10.0` -> `1.0.0-beta.5`
* Micronaut `4.8.2` -> `4.10.7`
* Guava `33.4.8-jre` -> `33.5.0-jre`

